### PR TITLE
updated babel preset to ensure transpiling to es5 friendly code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+	"presets": ["env"],
     "plugins": [
         "transform-es2015-modules-commonjs",
         "transform-object-rest-spread"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-eslint": "^7.1.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.19.0",
+    "babel-preset-env": "^1.6.1",
     "coveralls": "^2.11.15",
     "eslint": "^3.10.2",
     "mocha": "^3.1.2",


### PR DESCRIPTION
@PabloSichert, I found the distributed files still contained ES6 code (such as function default arguments), so I added the 'env' preset to Babel, to ensure the output code was completely ES5 friendly.